### PR TITLE
修复私有化会议配置初始化

### DIFF
--- a/meeting-electron/packages/meeting-app-electron/package.json
+++ b/meeting-electron/packages/meeting-app-electron/package.json
@@ -120,6 +120,10 @@
     },
     "extraResources": [
       {
+        "from": "../meeting-kit-electron/xkit_server_private.json",
+        "to": "xkit_server_private.json"
+      },
+      {
         "from": "assets/VC_redist.X64.exe",
         "to": "."
       }

--- a/meeting-electron/packages/meeting-app-electron/src/index.js
+++ b/meeting-electron/packages/meeting-app-electron/src/index.js
@@ -60,7 +60,6 @@ if (!fs.existsSync(userDataPath)) {
   }
 }
 
-const privateConfigPath = path.join(userDataPath, privateConfigFileName)
 // 定义日志目录名称
 const cacheDirectoryName = 'logs'
 
@@ -107,21 +106,24 @@ if (!fs.existsSync(logPath)) {
   fs.mkdirSync(logPath)
 }
 
-const innerPrivateConfigPath = path.join(__dirname, privateConfigFileName)
+function resolvePrivateConfigPath() {
+  const candidates = [
+    // Packaged app: electron-builder copies extraResources here.
+    path.join(process.resourcesPath, privateConfigFileName),
+    // Local development: keep the source config in meeting-kit-electron.
+    path.resolve(
+      __dirname,
+      '../../meeting-kit-electron',
+      privateConfigFileName
+    ),
+    // Backward compatibility with the previous app-local config location.
+    path.join(__dirname, privateConfigFileName),
+  ]
 
-getPrivateConfig()
-
-function getPrivateConfig() {
-  try {
-    // 如果存在配置文件
-    if (fs.existsSync(innerPrivateConfigPath)) {
-      console.log('存在私有化配置文件')
-      fs.copyFileSync(innerPrivateConfigPath, privateConfigPath)
-    }
-  } catch (error) {
-    console.log('copyPrivateConfig error', error)
-  }
+  return candidates.find((filePath) => fs.existsSync(filePath))
 }
+
+const privateConfigPath = resolvePrivateConfigPath()
 
 function dealLoginSuccess(url) {
   beforeMeetingWindow?.webContents.send('electron-login-success', url)
@@ -192,9 +194,9 @@ app.whenReady().then(() => {
       return privateConfig
     }
 
-    if (fs.existsSync(privateConfigPath)) {
+    if (privateConfigPath) {
       privateConfig = require(privateConfigPath)
-      console.log('privateConfig', privateConfig)
+      console.log('privateConfig', privateConfigPath, privateConfig)
     } else {
       privateConfig = null
     }

--- a/meeting-electron/packages/meeting-app-web/src/api/request.ts
+++ b/meeting-electron/packages/meeting-app-web/src/api/request.ts
@@ -7,8 +7,49 @@ const axiosInstance = axios.create({
   baseURL: DOMAIN_SERVER,
 });
 
+let cachedPrivateConfig: {
+  meetingServerDomain?: string;
+  meeting?: {
+    serverUrl?: string;
+  };
+} | null = null;
+let privateConfigLoading: Promise<void> | null = null;
+
+function ensurePrivateConfigReady() {
+  if (!window.isElectronNative) {
+    return Promise.resolve();
+  }
+
+  if (cachedPrivateConfig) {
+    return Promise.resolve();
+  }
+
+  if (!privateConfigLoading) {
+    privateConfigLoading =
+      window.ipcRenderer
+        ?.invoke('getPrivateConfig')
+        .then((privateConfig) => {
+          cachedPrivateConfig = privateConfig;
+          const meetingServerUrl =
+            privateConfig?.meetingServerDomain ||
+            privateConfig?.meeting?.serverUrl;
+
+          if (meetingServerUrl) {
+            axiosInstance.defaults.baseURL = meetingServerUrl;
+          }
+        })
+        .catch((error) => {
+          console.log('getPrivateConfig error', error);
+        }) || Promise.resolve();
+  }
+
+  return privateConfigLoading;
+}
+
 axiosInstance.interceptors.request.use(
-  function (config) {
+  async function (config) {
+    await ensurePrivateConfigReady();
+
     config.headers = {
       ...config.headers,
       clientType: 'Web',

--- a/meeting-electron/packages/meeting-app-web/src/components/web/BeforeMeetingHome/index.tsx
+++ b/meeting-electron/packages/meeting-app-web/src/components/web/BeforeMeetingHome/index.tsx
@@ -831,20 +831,22 @@ const BeforeMeetingHome: React.FC<BeforeMeetingHomeProps> = ({ onLogout }) => {
     };
     // 判断是否有私有化配置文件
     let privateConfig: NEMeetingPrivateConfig | null = null;
+    let rawPrivateConfig: NEMeetingPrivateConfig | null = null;
 
     if (window.isElectronNative) {
       try {
-        privateConfig = await window.ipcRenderer?.invoke(
+        rawPrivateConfig = await window.ipcRenderer?.invoke(
           IPCEvent.getPrivateConfig,
         );
         privateConfig = parsePrivateConfig(
-          privateConfig as NEMeetingPrivateConfig,
+          rawPrivateConfig as NEMeetingPrivateConfig,
         );
       } catch (error) {
         console.log('getPrivateConfig error', error);
       }
     } else {
       privateConfig = PRIVATE_CONFIG as unknown as NEMeetingPrivateConfig;
+      rawPrivateConfig = privateConfig;
       console.log('privateConfig>>>', privateConfig);
     }
 
@@ -861,10 +863,24 @@ const BeforeMeetingHome: React.FC<BeforeMeetingHomeProps> = ({ onLogout }) => {
       nosAntiLeech: true,
       nosAntiLeechExpire: 7200,
     };
+    const serverConfig = privateConfig
+      ? {
+          imServerConfig: privateConfig.imPrivateConf,
+          rtcServerConfig: privateConfig.neRtcServerAddresses,
+          whiteboardServerConfig: privateConfig.whiteboardConfig,
+        }
+      : undefined;
 
     return MeetingKitInstance.initialize({
       appKey: config.appKey,
       serverUrl: config.meetingServerDomain,
+      useAssetServerConfig: window.isElectronNative && !!privateConfig,
+      serverConfig,
+      extras: {
+        serverConfigJsonString: rawPrivateConfig
+          ? JSON.stringify(rawPrivateConfig)
+          : '',
+      },
       width: 0,
       height: 0,
       whiteboardAppConfig,

--- a/meeting-electron/packages/meeting-kit-core/src/services/NEMeeting.ts
+++ b/meeting-electron/packages/meeting-kit-core/src/services/NEMeeting.ts
@@ -576,14 +576,10 @@ export default class NEMeetingService {
       useInternalVideoRender: false,
       debug: params.debug,
       eventTracking: params.eventTracking,
-      extras: params.extras?.noReport
-        ? {
-            noReport: params.extras?.noReport,
-            framework: this._framework,
-          }
-        : {
-            framework: this._framework,
-          },
+      extras: {
+        ...params.extras,
+        framework: this._framework,
+      },
     }
 
     // 配置私有化优先级更高 > serverUrl
@@ -602,7 +598,7 @@ export default class NEMeetingService {
         rtcServerConfig: params.neRtcServerAddresses,
         whiteboardServerConfig: params.whiteboardConfig,
       }
-      // options.useAssetServerConfig = true
+      ;(options as any).useAssetServerConfig = !!params.useAssetServerConfig
     } else if (params.useAssetServerConfig) {
       // Electron读取配置文件
       try {

--- a/meeting-electron/packages/meeting-kit-core/src/utils/index.ts
+++ b/meeting-electron/packages/meeting-kit-core/src/utils/index.ts
@@ -880,6 +880,8 @@ export function parsePrivateConfig(privateConfig: NEMeetingPrivateConfig) {
   const imConfig = privateConfig.im
   const rtcConfig = privateConfig.rtc
   const whiteboardConfig = privateConfig.whiteboard
+  const meetingServerDomain =
+    privateConfig.meetingServerDomain || privateConfig.meeting?.serverUrl
   const im = {
     ...imConfig,
     handShakeType: imConfig?.hand_shake_type,
@@ -920,6 +922,7 @@ export function parsePrivateConfig(privateConfig: NEMeetingPrivateConfig) {
     fontDownloadServer: whiteboardConfig?.fontDownloadServer,
   }
   const options: {
+    meetingServerDomain?: string
     imPrivateConf: typeof im
     neRtcServerAddresses: typeof rtc
     whiteboardConfig: typeof whiteboard
@@ -927,6 +930,7 @@ export function parsePrivateConfig(privateConfig: NEMeetingPrivateConfig) {
       roomServer: string
     }
   } = {
+    meetingServerDomain,
     imPrivateConf: im,
     neRtcServerAddresses: rtc,
     whiteboardConfig: whiteboard,


### PR DESCRIPTION
## 背景

Electron 私有化场景下，xkit_server_private.json 已经能通过打包资源读取，但 app-web 请求和 native RoomKit 初始化没有完整使用该配置，导致部分请求仍可能落到公有域名，IM 私有链路配置也可能未传到底层 SDK。

## 变更内容

- 在 app-web 请求前读取并缓存私有化配置，将请求 baseURL 切到 meeting.serverUrl
- 初始化 MeetingKit 时传入私有化 serverConfig
- 同时传入原始 serverConfigJsonString，供 native RoomKit 初始化使用
- 保留 RoomKit 初始化参数中的 extras，避免私有化配置字符串被过滤
- parsePrivateConfig 支持从 meeting.serverUrl 解析会议服务域名

## 验证结果

- [x] pnpm -F nemeeting-app-web build
- [x] pnpm -F nemeeting-electron-sdk build:lib
- [x] pnpm -F nemeeting-app-electron start:prod
- [x] 验证 RoomKit 登录请求走私有化会议服务域名
- [x] 验证日志出现 IM V2 Command channel login success

## 说明

本次改动不复制 xkit_server_private.json 到运行时目录，只通过打包资源和现有读取链路使用该配置。
